### PR TITLE
Fastlane updates

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(FLUTTER_BUILD_NAME)</string>
+	<string>1.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -23,13 +23,19 @@ platform :ios do
       scheme: "Runner",
     )
   end
-  desc "Increment the build number"
+  # desc "Increment the build number"
+  # lane :increment_build_number do
+  #   latest_release = firebase_app_distribution_get_latest_release(
+  #     app: "1:969395528079:ios:120b02032f7882f7066bfa"
+  #   )
+  #   increment_build_number({ build_number: latest_release[:buildVersion].to_i + 1 })
+  # end
+  desc "Increment the version"
   lane :increment_version do
-    latest_release = firebase_app_distribution_get_latest_release(
-      app: "1:969395528079:ios:120b02032f7882f7066bfa"
+    increment_version_number(
+      version_number: "1.0.1"
     )
-    increment_build_number({ build_number: latest_release[:buildVersion].to_i + 1 })
-  end
+  end 
   desc "Build and Distribute the iOS app"
   lane :distribute_ios do
     increment_version
@@ -37,7 +43,7 @@ platform :ios do
     firebase_app_distribution(
       app: "1:969395528079:ios:120b02032f7882f7066bfa",
       groups: "dev",
-      release_notes: "No release notes",
+      release_notes: "Infinite Loading Screen Fixed , Invalid Room Code handled ",
     )
   end
 end

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -33,7 +33,7 @@ platform :ios do
   desc "Increment the version"
   lane :increment_version do
     increment_version_number(
-      version_number: "1.0.1"
+      bump_type: "patch"
     )
   end 
   desc "Build and Distribute the iOS app"

--- a/ios/fastlane/README.md
+++ b/ios/fastlane/README.md
@@ -29,7 +29,7 @@ Build the iOS app
 [bundle exec] fastlane ios increment_version
 ```
 
-Increment the build number
+Increment the version
 
 ### ios distribute_ios
 

--- a/ios/fastlane/report.xml
+++ b/ios/fastlane/report.xml
@@ -5,42 +5,12 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000329">
+      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000337">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="1: Switch to ios increment_version lane" time="0.000702">
-        
-      </testcase>
-    
-      
-      <testcase classname="fastlane.lanes" name="2: increment_version_number" time="0.290759">
-        
-      </testcase>
-    
-      
-      <testcase classname="fastlane.lanes" name="3: Switch to ios build lane" time="0.000317">
-        
-      </testcase>
-    
-      
-      <testcase classname="fastlane.lanes" name="4: is_ci" time="0.002241">
-        
-      </testcase>
-    
-      
-      <testcase classname="fastlane.lanes" name="5: match" time="22.879402">
-        
-      </testcase>
-    
-      
-      <testcase classname="fastlane.lanes" name="6: build_ios_app" time="101.620451">
-        
-      </testcase>
-    
-      
-      <testcase classname="fastlane.lanes" name="7: firebase_app_distribution" time="46.813322">
+      <testcase classname="fastlane.lanes" name="1: increment_version_number" time="0.287884">
         
       </testcase>
     

--- a/ios/fastlane/report.xml
+++ b/ios/fastlane/report.xml
@@ -5,47 +5,42 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000319">
+      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000329">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="1: Switch to ios increment_version lane" time="0.001311">
+      <testcase classname="fastlane.lanes" name="1: Switch to ios increment_version lane" time="0.000702">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="2: firebase_app_distribution_get_latest_release" time="0.744328">
+      <testcase classname="fastlane.lanes" name="2: increment_version_number" time="0.290759">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="3: increment_build_number" time="1.298211">
+      <testcase classname="fastlane.lanes" name="3: Switch to ios build lane" time="0.000317">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="4: Switch to ios build lane" time="0.000192">
+      <testcase classname="fastlane.lanes" name="4: is_ci" time="0.002241">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="5: is_ci" time="0.000217">
+      <testcase classname="fastlane.lanes" name="5: match" time="22.879402">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="6: match" time="11.912247">
+      <testcase classname="fastlane.lanes" name="6: build_ios_app" time="101.620451">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="7: build_ios_app" time="73.452024">
-        
-      </testcase>
-    
-      
-      <testcase classname="fastlane.lanes" name="8: firebase_app_distribution" time="10.564609">
+      <testcase classname="fastlane.lanes" name="7: firebase_app_distribution" time="46.813322">
         
       </testcase>
     


### PR DESCRIPTION
Fastlane distribute will not correctly update the version number instead of the build number , currently just updating the patch number